### PR TITLE
Update rafaelhdr:google-charts.js

### DIFF
--- a/rafaelhdr:google-charts.js
+++ b/rafaelhdr:google-charts.js
@@ -45,7 +45,7 @@ if (Meteor.isClient) {
 
   // Code for meteor
 
-  google.load('visualization', '1.0', {'packages':['corechart'], callback: drawChart});
+  google.load('visualization', '1.0', {'packages':['corechart', 'timeline'], callback: drawChart});
 
   drawChart = function (chart) {
     var data = new google.visualization.DataTable();


### PR DESCRIPTION
Add support for Timeline chart type.

The package currently does not display "timeline" charts. This change seems to do the job.

Kind regards
James
